### PR TITLE
Add SRI hash to safe-email CDN script

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -3,7 +3,7 @@ layout: home
 ---
 
 <!--- Script for obscuring email--->
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/safe-email@1.1.1/dist/safe-email.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/safe-email@1.1.1/dist/safe-email.min.js" integrity="sha384-LDoX5vG5rC69DJ5YROnO9cYwP8zdpq+AK/fnDuUtkiFYIqerzEYGMjLDj/q36Ov4" crossorigin="anonymous"></script>
 
 <img src="images/year_2_headshot.jpg" width="40%" align="left" style="padding-right: 30px;">
 


### PR DESCRIPTION
## Summary
- Pin `safe-email@1.1.1` loaded from jsDelivr with a SHA-384 `integrity` attribute and `crossorigin="anonymous"` so a compromised or swapped CDN copy can't execute arbitrary JS on visitors.
- One-line change to `index.markdown:6`. Closes #3.

## Test plan
- [x] Recomputed `curl -sL https://cdn.jsdelivr.net/npm/safe-email@1.1.1/dist/safe-email.min.js | openssl dgst -sha384 -binary | openssl base64 -A` → matches the hash committed.
- [x] Confirmed the `data-email_b64` attribute base64-decodes to `gsmoore@stanford.edu` (unchanged by this PR).
- [ ] Run `bundle exec jekyll serve`, open the homepage, click the email link, verify it opens a `mailto:gsmoore@stanford.edu` handler with no SRI errors in the console. *(Couldn't run locally — system Ruby lacks the bundler version pinned in `Gemfile.lock`. Please verify before merge, or rely on the gh-pages build preview.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)