### PR TITLE
Remove plaintext email from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,7 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: Gideon Moore 
-email: gsmoore@stanford.edu
+title: Gideon Moore
 description: >- # this means to ignore newlines until "baseurl:"
   Economics PhD Student at Stanford University
 baseurl: "" # the subpath of your site, e.g. /blog


### PR DESCRIPTION
## Summary
- Closes #4. Deletes the top-level `email:` key from `_config.yml` so no Jekyll plugin or theme template can render the address in plaintext.
- Keeps the existing homepage obfuscation (base64 + `safe-email` JS at `index.markdown:14`) as the only place the address appears in the source, intentionally hidden from naive scrapers.

## Why this is safe today
Investigation of the actual rendered surfaces:
- `_includes/footer.html` overrides Minima's default and reads `site.author.email` (undefined), not `site.email`. No leak today.
- `jekyll-feed` 0.12.x's `feed.xml` template only emits `<email>` from `site.author.email`, not `site.email`. No leak today.
- `jekyll-seo-tag` (loaded transitively by `github-pages`) does not reference email at all.

So `site.email` was effectively a dead key. Removing it is defense in depth — if the footer override is ever removed or Minima's default is restored, the obfuscation will still hold.

## Test plan
- [ ] Wait for the GitHub Pages deploy to publish.
- [ ] `curl -s https://www.gideonmoore.com/feed.xml | grep -i gsmoore` → expect zero matches.
- [ ] `curl -s https://www.gideonmoore.com/ | grep -i gsmoore` → expect only the base64 blob `Z3Ntb29yZUBzdGFuZm9yZC5lZHU=`, no plaintext address.
- [ ] Visit the homepage in a browser — the mailto link in the "easiest to reach me by email at …" sentence should still resolve to `gsmoore@stanford.edu` via the safe-email JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)