### PR TITLE
Drop minima gem; remote_theme is the single source of truth (closes #6)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 # gem "jekyll", "~> 4.2.1"
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
 gem "github-pages", "~> 232", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,6 @@ PLATFORMS
 DEPENDENCIES
   github-pages (~> 232)
   jekyll-feed (~> 0.12)
-  minima (~> 2.5)
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)


### PR DESCRIPTION
## Summary
- Removes `gem "minima", "~> 2.5"` from `Gemfile` and its `DEPENDENCIES` entry from `Gemfile.lock`. `minima 2.5.1` remains in the lock file as a transitive dep of `github-pages 232` — that's unavoidable and matches what production already installs.
- `_config.yml:38` (`remote_theme: jekyll/minima@acb0519`) is now the sole source of theme truth, matching how GitHub Pages builds the site in production.
- The `acb0519` pin is load-bearing — it's the Minima commit that adds the BlueSky icon used at `_config.yml:59-61`; Minima 2.5 doesn't have it.

## Test plan
- [x] `bundle install` resolves cleanly under Ruby 3.4 + Bundler 4.0.12 (97 gems, 6 top-level deps).
- [x] `bundle exec jekyll serve` builds without theme errors.
- [x] Local HTML at `127.0.0.1:4000` contains the BlueSky icon (`fa-brands fa-bluesky`) — confirms the newer `acb0519` remote theme is what's serving locally, not the old gem.
- [x] Local social-link block is byte-identical to the live site at https://www.gideonmoore.com (Twitter, GitHub, LinkedIn, BlueSky in that order).
- [x] Header nav order matches live (Education / Experience / Research / Awards).
- [ ] After merge: confirm the live site at https://www.gideonmoore.com still renders correctly (no expected change — production already used `remote_theme`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)